### PR TITLE
lineage: Set perms on reading_mode sysfs

### DIFF
--- a/prebuilt/common/etc/init/lineage-livedisplay.rc
+++ b/prebuilt/common/etc/init/lineage-livedisplay.rc
@@ -12,3 +12,5 @@ on boot
     chmod 0660 /sys/devices/virtual/graphics/fb0/sre
     chown system system /sys/devices/virtual/graphics/fb0/color_enhance
     chmod 0660 /sys/devices/virtual/graphics/fb0/color_enhance
+    chown system system /sys/devices/virtual/graphics/fb0/reading_mode
+    chmod 0660 /sys/devices/virtual/graphics/fb0/reading_mode


### PR DESCRIPTION
* This is now supported by the common sysfs impl,
  so the perms should be set on the node

Change-Id: I079301a8684f3038b7e5e72b7b2d830259c4fe60