### PR TITLE
Fix bootanimation destpath if building off-tree

### DIFF
--- a/bootanimation/Android.mk
+++ b/bootanimation/Android.mk
@@ -25,7 +25,8 @@ ifeq ($(TARGET_SCREEN_HEIGHT),)
 endif
 
 define build-bootanimation
-    sh vendor/lineage/bootanimation/generate-bootanimation.sh \
+    $(shell) vendor/lineage/bootanimation/generate-bootanimation.sh \
+    $(PRODUCT_OUT) \
     $(TARGET_SCREEN_WIDTH) \
     $(TARGET_SCREEN_HEIGHT) \
     $(TARGET_BOOTANIMATION_HALF_RES)

--- a/bootanimation/generate-bootanimation.sh
+++ b/bootanimation/generate-bootanimation.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-WIDTH="$1"
-HEIGHT="$2"
-HALF_RES="$3"
-OUT="$ANDROID_PRODUCT_OUT/obj/BOOTANIMATION"
+PRODUCT_OUT="$1"
+WIDTH="$2"
+HEIGHT="$3"
+HALF_RES="$4"
+
+OUT="$PRODUCT_OUT/obj/BOOTANIMATION"
 
 if [ "$HEIGHT" -lt "$WIDTH" ]; then
     IMAGEWIDTH="$HEIGHT"
@@ -24,7 +26,7 @@ RESOLUTION=""$IMAGEWIDTH"x"$IMAGEHEIGHT""
 
 for part_cnt in 0 1 2 3 4
 do
-    mkdir -p $ANDROID_PRODUCT_OUT/obj/BOOTANIMATION/bootanimation/part$part_cnt
+    mkdir -p "$OUT/bootanimation/part$part_cnt"
 done
 tar xfp "vendor/lineage/bootanimation/bootanimation.tar" -C "$OUT/bootanimation/"
 mogrify -resize $RESOLUTION -colors 250 "$OUT/bootanimation/"*"/"*".png"


### PR DESCRIPTION
If the build is invoked off-tree, like:

    . build/envsetup.sh
    export OUT_DIR=/some/other/dir/out
    export DIST_DIR=/some/other/dir/dist
    breakfast chagalllte
    mka \
        target-files-package dist

the bootanimation.zip is correctly generated in $OUT_DIR.

However, if the user overrides directories after breakfast, i.e:

    . build/envsetup.sh
    breakfast chagalllte
    mka \
        OUT_DIR=/some/other/dir/out \
        DIST_DIR=/some/other/dir/dist \
        target-files-package dist

the destination path of intermediate bootanimation.zip is still
controlled by $ANDROID_PRODUCT_OUT which is set by build/envsetup.sh.
This leads to a copy error and a failed build.

The fix overrides $ANDROID_PRODUCT_OUT by the always-known PRODUCT_OUT
(make variable defined in build/core/envsetup.mk), making it error-prone
to environment variable declaration.

Also, the "sh" invocation is replaced with generic make-variable
$(shell).

Change-Id: Ic94d1b538fc01946b628f9b5d776548a03acde97
Signed-off-by: Vasyl Gello <vasek.gello@gmail.com>