### PR TITLE
overlay: Use ntp.ntsc.ac.cn NTP server for Chinese users

### DIFF
--- a/overlay/common/frameworks/base/core/res/res/values-mcc460/config.xml
+++ b/overlay/common/frameworks/base/core/res/res/values-mcc460/config.xml
@@ -2,6 +2,7 @@
 <!--
 /*
 ** Copyright 2018, The LineageOS Project
+** Copyright 2018-2019, The MoKee Open Source Project
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -19,5 +20,5 @@
 
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <!-- Remote server that can provide NTP responses. -->
-    <string translatable="false" name="config_ntpServer">2.android.pool.ntp.org</string>
+    <string translatable="false" name="config_ntpServer">ntp.ntsc.ac.cn</string>
 </resources>


### PR DESCRIPTION
Old one no longer works.

Change-Id: If04d87ded94ceb08c7265569503bd51e7c06c542