### PR TITLE
roomservice: support new manifest formats.

### DIFF
--- a/build/tools/roomservice.py
+++ b/build/tools/roomservice.py
@@ -110,8 +110,21 @@ def indent(elem, level=0):
         if level and (not elem.tail or not elem.tail.strip()):
             elem.tail = i
 
-def get_default_revision():
+def get_manifest_path():
+    '''Find the current manifest path
+    In old versions of repo this is at .repo/manifest.xml
+    In new versions, .repo/manifest.xml includes an include
+    to some arbitrary file in .repo/manifests'''
+
     m = ElementTree.parse(".repo/manifest.xml")
+    try:
+        m.findall('default')[0]
+        return '.repo/manifest.xml'
+    except IndexError:
+        return ".repo/manifests/{}".format(m.find("include").get("name"))
+
+def get_default_revision():
+    m = ElementTree.parse(get_manifest_path())
     d = m.findall('default')[0]
     r = d.get('revision')
     return r.replace('refs/heads/', '').replace('refs/tags/', '')
@@ -142,7 +155,7 @@ def is_in_manifest(projectpath):
 
     # Search in main manifest, too
     try:
-        lm = ElementTree.parse(".repo/manifest.xml")
+        lm = ElementTree.parse(get_manifest_path())
         lm = lm.getroot()
     except:
         lm = ElementTree.Element("manifest")


### PR DESCRIPTION
.repo/manifest.xml is no longer a symlink becuase apparently windows
developers need to use repo and windows needs admin for symlinks.

https: //gerrit.googlesource.com/git-repo/+/a269b1cb9dc21dfd598bfea3766206b606ad4589
Change-Id: I88ea0295133959136d7214f13a76b66d89dc88d4
(cherry picked from commit f8adf067fddcb617e1c491caa3938c1329c526fb)